### PR TITLE
Use fixed version of database cookbook

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -44,7 +44,7 @@ cookbook 'apt', '2.4.0'
 cookbook 'runit', '1.5.10'
 cookbook 'nginx', '2.7.4'
 cookbook 'mysql', '5.3.6'
-cookbook 'database', '2.3.0'
+cookbook 'database', '2.3.1'
 #cookbook 'postgresql', '3.4.2'
 cookbook 'rvm', '0.9.2'
 


### PR DESCRIPTION
2.3.0 did not lock it's use of mysql-chef_gem, which recently removed it's default recipe.

database cookbook issue: https://github.com/opscode-cookbooks/database/issues/99
Fixing Commit: https://github.com/opscode-cookbooks/database/commit/2382445ae2ffae4776c642a6fa6a00102041d418

Previous error:

```
vagrant provision
==> app-server: Chef 11.18.6 Omnibus package is already installed.
==> app-server: Running provisioner: chef_solo...
==> app-server: Detected Chef (latest) is already installed
Generating chef JSON and uploading...
==> app-server: Running chef-solo...
==> app-server: [2015-04-04T23:48:27+00:00] INFO: Forking chef instance to converge...
==> app-server: [2015-04-04T23:48:27+00:00] INFO: *** Chef 11.18.6 ***
==> app-server: [2015-04-04T23:48:27+00:00] INFO: Chef-client pid: 7510
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Setting the run_list to ["basic_config", "apt", "mysql::client", "mysql::server", "rvm", "nginx", "rails_server"] from CLI options
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Run List is [recipe[basic_config], recipe[apt], recipe[mysql::client], recipe[mysql::server], recipe[rvm], recipe[nginx], recipe[rails_server]]
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Run List expands to [basic_config, apt, mysql::client, mysql::server, rvm, nginx, rails_server]
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Starting Chef Run for app-server
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Running start handlers
==> app-server: [2015-04-04T23:48:58+00:00] INFO: Start handlers complete.
==> app-server: [2015-04-04T23:48:59+00:00] ERROR: Running exception handlers
==> app-server: [2015-04-04T23:48:59+00:00] ERROR: Exception handlers complete
==> app-server: [2015-04-04T23:48:59+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> app-server: [2015-04-04T23:48:59+00:00] ERROR: Cookbook database not found. If you're loading database from another cookbook, make sure you configure the dependency in your metadata
==> app-server: [2015-04-04T23:48:59+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
